### PR TITLE
feat: add support for a persistent ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
-        if: matrix.arch != '386' && matrix.arch != 'amd64'
+        if: matrix.arch != 'amd64'
         with:
           platforms: ${{ steps.prep.outputs.qemu_platform }}
       - name: Set up buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.10.0@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5
 FROM ksmanis/stage3:20240930@sha256:8e8a7c86ab167ea0b740664492e78dc97c33cc59f6fff13bf4ac40bca7804a37 AS distcc-builder
+ARG CCACHE_DIR=/var/cache/ccache
+ENV CCACHE_DIR=$CCACHE_DIR
 RUN --mount=type=bind,from=ksmanis/gentoo-distcc:tcp,source=/var/cache/binpkgs,target=/cache \
     --mount=type=bind,from=ksmanis/portage,source=/var/db/repos/gentoo,target=/var/db/repos/gentoo \
     set -eux; \
@@ -8,10 +10,18 @@ RUN --mount=type=bind,from=ksmanis/gentoo-distcc:tcp,source=/var/cache/binpkgs,t
     emerge --info; \
     emerge distcc; \
     distcc --version; \
+    emerge ccache; \
+    ccache --version; \
+    echo "CCACHE_DIR=${CCACHE_DIR}" > /etc/env.d/02distcc-ssh-ccache; \
+    env-update; \
+    mkdir "${CCACHE_DIR}"; \
+    chmod 0775 "${CCACHE_DIR}"; \
+    chown distcc:distcc "${CCACHE_DIR}"; \
     emerge --oneshot gentoolkit; \
     eclean packages; \
     CLEAN_DELAY=0 emerge --depclean gentoolkit; \
     find /var/cache/distfiles/ -mindepth 1 -delete -print
+VOLUME $CCACHE_DIR
 
 FROM distcc-builder AS distcc-tcp
 ARG TARGETPLATFORM

--- a/docker-entrypoint-ssh.sh
+++ b/docker-entrypoint-ssh.sh
@@ -26,6 +26,10 @@ if [ "$1" = "sshd" ]; then
     fi
     # Execute sshd using absolute path
     shift
+    if [ "${DISTCC_CCACHE_ENABLE}" = 1 ]; then
+        echo "PATH=/usr/lib/ccache/bin" >> /etc/env.d/02distcc-ssh-ccache
+        env-update
+    fi
     exec /usr/sbin/sshd "$@"
 fi
 

--- a/docker-entrypoint-ssh.sh
+++ b/docker-entrypoint-ssh.sh
@@ -11,12 +11,12 @@ fi
 
 if [ "$1" = "sshd" ]; then
     # Create user and set up SSH access
-    id "${SSH_USERNAME}" >/dev/null 2>&1 || useradd "${SSH_USERNAME}"
+    id "${SSH_USERNAME}" >/dev/null 2>&1 || useradd -g distcc "${SSH_USERNAME}"
     mkdir -p "/home/${SSH_USERNAME}/.ssh"
-    chown "${SSH_USERNAME}:${SSH_USERNAME}" "/home/${SSH_USERNAME}/.ssh"
+    chown "${SSH_USERNAME}:distcc" "/home/${SSH_USERNAME}/.ssh"
     chmod 700 "/home/${SSH_USERNAME}/.ssh"
     echo "${AUTHORIZED_KEYS}" > "/home/${SSH_USERNAME}/.ssh/authorized_keys"
-    chown "${SSH_USERNAME}:${SSH_USERNAME}" "/home/${SSH_USERNAME}/.ssh/authorized_keys"
+    chown "${SSH_USERNAME}:distcc" "/home/${SSH_USERNAME}/.ssh/authorized_keys"
     chmod 600 "/home/${SSH_USERNAME}/.ssh/authorized_keys"
     # Create missing SSH host keys
     ssh-keygen -A

--- a/docker-entrypoint-tcp.sh
+++ b/docker-entrypoint-tcp.sh
@@ -6,6 +6,9 @@ set -e
 # * if hyphenated flag arguments (e.g., '-f', '-foo', or '--foo') were
 #   passed to the Docker command line
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    if [ "${DISTCC_CCACHE_ENABLE}" = 1 ]; then
+        export PATH="/usr/lib/ccache/bin:$PATH"
+    fi
     exec distccd --daemon --no-detach --log-level notice --log-stderr --allow-private "$@"
 fi
 


### PR DESCRIPTION
Closes: #64

The implementation is very simple. It boils down to installing the package `dev-util/ccache` in the container and adjusting `$PATH` if a `ccache.conf` is found under `/var/cache/ccache`. That config file existing indicates that `docker run` was invoked with a `--volume` mount and the intention to use ccache.

In the documentation i tried to cover some basics on how it could be used and monitored.

Now let me know what you think, what the actions say and if and how it could be tested. ccache itself probably does not require much testing, the biggest problem for users might be getting the filesystem permissions correct so that the user "distcc" with uid 240 can read and write the cache. Luckily the uid is known and fix with `acct-user/distcc`.