### PR TITLE
revert: enable docker compose colored output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           DOCKER_DEFAULT_PLATFORM: linux/${{ matrix.arch.id }}
         run: |
-          docker compose --ansi always -f docker-compose.test.yml -p test up \
+          docker compose -f docker-compose.test.yml -p test up \
             --exit-code-from distcc-${{ matrix.manifest }}-client \
             distcc-${{ matrix.manifest }}-client distcc-${{ matrix.manifest }}-server
       - name: Log in to Docker Hub


### PR DESCRIPTION
Related-to: https://github.com/docker/compose/pull/13074

This reverts commit 9044d3d90b76f345ec8ea615238c69cc5322411b.

This likely fixes build errors seen in recent PRs. The "ansi" color feature has had an upstream bug which seems to currently affect this repo. Dropping color support, at least for a while should fix it.