### PR TITLE
feat: add remote storage backends to ccache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,9 @@ RUN --mount=type=bind,from=ghcr.io/ksmanis/portage,source=/var/db/repos/gentoo,t
     getuto; \
     export EMERGE_DEFAULT_OPTS="--buildpkg --color=y --getbinpkg --jobs --quiet-build --tree --verbose"; \
     emerge --info; \
-    USE="redis http" emerge ccache; \
+    mkdir -p /etc/portage/package.use; \
+    echo 'dev-util/ccache http redis' > /etc/portage/package.use/ccache; \
+    emerge ccache; \
     ccache --version; \
     emerge --oneshot gentoolkit; \
     eclean packages; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN --mount=type=bind,from=ghcr.io/ksmanis/portage,source=/var/db/repos/gentoo,t
     getuto; \
     export EMERGE_DEFAULT_OPTS="--buildpkg --color=y --getbinpkg --jobs --quiet-build --tree --verbose"; \
     emerge --info; \
-    emerge ccache; \
+    USE="redis http" emerge ccache; \
     ccache --version; \
     emerge --oneshot gentoolkit; \
     eclean packages; \


### PR DESCRIPTION
Enable http and redis storage backends in dev-util/ccache to allow the
use of remote storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Enabled HTTP and Redis support for ccache during container image builds.
  * Added the required package configuration automatically during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->