### PR TITLE
ci: seed GitHub binrepo from package caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     continue-on-error: true
     permissions:
       attestations: write
-      contents: read
+      contents: write
       id-token: write
       packages: write
     strategy:
@@ -137,6 +137,9 @@ jobs:
         with:
           build-args: |
             BASE=${{ matrix.manifest.base }}
+            BINREPO_BRANCH=binrepo-${{ steps.prep.outputs.tag_arch }}-${{ matrix.manifest.id }}
+            BINREPO_PUBLISH=${{ github.event_name == 'push' && '1' || '' }}
+            BINREPO_REPOSITORY=${{ github.repository }}
             CLANG=${{ matrix.manifest.clang }}
             CROSSDEV_TARGETS=${{ env.CROSSDEV_TARGETS }}
           cache-from: |
@@ -147,6 +150,7 @@ jobs:
           labels: ${{ steps.docker-metadata.outputs.labels }}
           load: true
           platforms: linux/${{ matrix.arch.id }}
+          secrets: gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-metadata.outputs.tags }}
           target: distcc
       - name: Inspect image
@@ -166,6 +170,9 @@ jobs:
         with:
           build-args: |
             BASE=${{ matrix.manifest.base }}
+            BINREPO_BRANCH=binrepo-${{ steps.prep.outputs.tag_arch }}-${{ matrix.manifest.id }}
+            BINREPO_PUBLISH=${{ github.event_name == 'push' && '1' || '' }}
+            BINREPO_REPOSITORY=${{ github.repository }}
             CLANG=${{ matrix.manifest.clang }}
             CROSSDEV_TARGETS=${{ env.CROSSDEV_TARGETS }}
           cache-from: |
@@ -178,6 +185,7 @@ jobs:
           provenance: mode=max
           push: true
           sbom: true
+          secrets: gh_token=${{ secrets.GITHUB_TOKEN }}
           tags: ${{ steps.docker-metadata.outputs.tags }}
           target: distcc
       - name: Extract Docker mounts cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 # syntax=docker/dockerfile:1.26.0@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 ARG BASE=build-base
+ARG BINREPO_BRANCH=
+ARG BINREPO_PUBLISH=
+ARG BINREPO_REPOSITORY=
 
 FROM ghcr.io/ksmanis/stage3:20260817@sha256:99b37248a66bc90393f3ead3e8f8269dedc633a65e1d3928f97767b742e6ff46 AS build-base
+ARG BINREPO_BRANCH
+ARG BINREPO_PUBLISH
+ARG BINREPO_REPOSITORY
 ARG CLANG=
 ARG CROSSDEV_TARGETS=
 ARG TARGETPLATFORM
 RUN --mount=type=bind,from=ghcr.io/ksmanis/portage,source=/var/db/repos/gentoo,target=/var/db/repos/gentoo \
     --mount=type=cache,id=base,target=/var/cache/binpkgs \
+    --mount=type=secret,id=gh_token \
     set -eux; \
     getuto; \
     export EMERGE_DEFAULT_OPTS="--buildpkg --color=y --getbinpkg --jobs --quiet-build --tree --verbose"; \
@@ -35,18 +42,50 @@ RUN --mount=type=bind,from=ghcr.io/ksmanis/portage,source=/var/db/repos/gentoo,t
             crossdev --portage '--buildpkg --usepkg' --stable --target "${target}"; \
         done; \
     fi; \
+    if [ -n "${BINREPO_PUBLISH}" ]; then \
+        mkdir -p /var/db/repos/rookery; \
+        wget -nv 'https://github.com/KSmanis/rookery/archive/HEAD.tar.gz' -O /var/db/repos/rookery.tar.gz; \
+        tar -xzf /var/db/repos/rookery.tar.gz --strip-components=1 -C /var/db/repos/rookery; \
+        rm /var/db/repos/rookery.tar.gz; \
+        mkdir -p /etc/portage/repos.conf; \
+        printf '[rookery]\nauto-sync = no\nlocation = /var/db/repos/rookery\n' > /etc/portage/repos.conf/rookery.conf; \
+        ACCEPT_KEYWORDS='**' emerge --oneshot app-portage/portage-github-binrepo; \
+        printf 'branch = %s\nrepository = %s\ntoken-file = /run/secrets/gh_token\n' "${BINREPO_BRANCH}" "${BINREPO_REPOSITORY}" > /etc/portage/github-binrepo.conf; \
+        portage-github-binrepo check; \
+    fi; \
     emerge --oneshot gentoolkit; \
     eclean packages; \
+    if [ -n "${BINREPO_PUBLISH}" ]; then portage-github-binrepo push; fi; \
     CLEAN_DELAY=0 emerge --depclean gentoolkit; \
+    if [ -n "${BINREPO_PUBLISH}" ]; then \
+        CLEAN_DELAY=0 emerge --depclean app-portage/portage-github-binrepo; \
+        rm -rf /etc/portage/github-binrepo.conf /etc/portage/repos.conf/rookery.conf /var/db/repos/rookery; \
+    fi; \
     find /var/cache/distfiles/ -mindepth 1 -delete -print; \
     rm -rf /etc/portage/gnupg/
 
 FROM build-base AS build-ccache
+ARG BINREPO_BRANCH
+ARG BINREPO_PUBLISH
+ARG BINREPO_REPOSITORY
 RUN --mount=type=bind,from=ghcr.io/ksmanis/portage,source=/var/db/repos/gentoo,target=/var/db/repos/gentoo \
     --mount=type=cache,id=ccache,target=/var/cache/binpkgs \
+    --mount=type=secret,id=gh_token \
     set -eux; \
     getuto; \
     export EMERGE_DEFAULT_OPTS="--buildpkg --color=y --getbinpkg --jobs --quiet-build --tree --verbose"; \
+    if [ -n "${BINREPO_PUBLISH}" ]; then \
+        mkdir -p /var/db/repos/rookery; \
+        wget -nv 'https://github.com/KSmanis/rookery/archive/HEAD.tar.gz' -O /var/db/repos/rookery.tar.gz; \
+        tar -xzf /var/db/repos/rookery.tar.gz --strip-components=1 -C /var/db/repos/rookery; \
+        rm /var/db/repos/rookery.tar.gz; \
+        mkdir -p /etc/portage/repos.conf; \
+        printf '[rookery]\nauto-sync = no\nlocation = /var/db/repos/rookery\n' > /etc/portage/repos.conf/rookery.conf; \
+        ACCEPT_KEYWORDS='**' emerge --oneshot app-portage/portage-github-binrepo; \
+        printf 'branch = %s\nrepository = %s\ntoken-file = /run/secrets/gh_token\n' "${BINREPO_BRANCH}" "${BINREPO_REPOSITORY}" > /etc/portage/github-binrepo.conf; \
+        portage-github-binrepo check; \
+        portage-github-binrepo pull; \
+    fi; \
     emerge --info; \
     mkdir -p /etc/portage/package.use; \
     echo 'dev-util/ccache http redis' > /etc/portage/package.use/ccache; \
@@ -54,7 +93,12 @@ RUN --mount=type=bind,from=ghcr.io/ksmanis/portage,source=/var/db/repos/gentoo,t
     ccache --version; \
     emerge --oneshot gentoolkit; \
     eclean packages; \
+    if [ -n "${BINREPO_PUBLISH}" ]; then portage-github-binrepo push; fi; \
     CLEAN_DELAY=0 emerge --depclean gentoolkit; \
+    if [ -n "${BINREPO_PUBLISH}" ]; then \
+        CLEAN_DELAY=0 emerge --depclean app-portage/portage-github-binrepo; \
+        rm -rf /etc/portage/github-binrepo.conf /etc/portage/repos.conf/rookery.conf /var/db/repos/rookery; \
+    fi; \
     find /var/cache/distfiles/ -mindepth 1 -delete -print; \
     rm -rf /etc/portage/gnupg/
 ARG CCACHE_DIR=/var/cache/ccache


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container image builds with configurable package repository branches and publishing options.
  * Added package availability checks and improved cache reuse during builds.
  * Enhanced build workflows to support package publishing when enabled.
  * Improved build authentication and cleanup of temporary repository configuration and credentials.
  * Updated image build permissions and tooling to support reliable artifact publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->